### PR TITLE
Add bypass by window title facility

### DIFF
--- a/config.sample.txt
+++ b/config.sample.txt
@@ -1,3 +1,4 @@
 remap_key=CAPSLOCK
 when_alone=ESCAPE
 with_other=CTRL
+bypass_with_title=Remote Desktop Connection


### PR DESCRIPTION
Provides the facility to bypass all mapping and injection functionality when the foreground window has a title that matches any one of a set of configured strings.

For example, when using the Windows RDP client, the corresponding window will have a title containing the string "Remote Desktop Connection", in this case, a configuration line will ensure that keys aren't mapped and injections don't happen so that problems related to certain keys not being reported to the hook procedure are averted.  In this case, and if required, a separate instance of `dual-key-remap` may be run on the target host.

Example of such a configuration line:

    bypass_with_title=Remote Desktop Connection